### PR TITLE
Prevent redirect on lobby input

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -56,7 +56,10 @@ class App extends React.Component {
   }
 
   handleInput(e) {
-    this.setState({lobby: e.target.value})
+    this.setState({
+      lobby: e.target.value,
+      redirect: false
+    })
   }
 
   handleKeyPress(e) {


### PR DESCRIPTION
Fix for #5, which is caused by the state persisting between visits to the main page.

This fix resets `state.redirect` to `false` when we update the state in `handleInput()`, but the issue would still persist if in the future the `<App />` component could update before `handleInput()` resets `state.redirect` and `state.lobby` (both values persist).

A better fix would be to refactor `<AppContainer />` as its own component, and reset the `state.redirect` in its `componentDidMount()`. Hypothetically.